### PR TITLE
Clean up requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,7 @@ requirements:
     - python >=3.6
   run:
     - python >=3.7
-    - future  # >=0.17.1
-    - packaging
+    - packaging >=17.0
     - numpy  >=1.17.2
     - pyyaml  >=5.4
     - pytorch >=1.9
@@ -30,7 +29,6 @@ requirements:
     - fsspec[http] >=2021.05.0, !=2021.06.0
     - torchmetrics >=0.7.0
     - pyDeprecate >=0.3.1, <0.4
-    - setuptools <=59.5  # temp solution for Tensorboard using `distutils.version.LooseVersion`
     - typing-extensions >=4.0.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 605ab313e54992261db74df4a6a6d4d556f319ea8a08eff2f30d80e8b898eb14
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -28,7 +28,7 @@ requirements:
     - tensorboard >=2.9.1
     - fsspec[http] >=2021.05.0, !=2021.06.0
     - torchmetrics >=0.7.0
-    - pyDeprecate >=0.3.1, <0.4
+    - pyDeprecate >=0.3.1
     - typing-extensions >=4.0.0
 
 test:


### PR DESCRIPTION
The `setuptools` requirement doesn't seem to be necessary anymore and appears to be causing dependency conflicts (for our `u8darts-torch` package for example). This PR brings the requirements in line with those of the PyPI package.

Resolves #83.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
