### PR TITLE
Manual bump to pytorch-lightning v1.8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytorch-lightning" %}
-{% set version = "1.7.7" %}
+{% set version = "1.8.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 27c2dd01a18db2415168e3fa3775ccb5a1fa1e2961a50439ad9365507fe9d4ae
+  sha256: 5b60e5eb84dd16ee8dc408286f0074ab475bed385b09a702d678ccbde91e4818
 
 build:
   number: 0
@@ -20,16 +20,16 @@ requirements:
     - python >=3.6
   run:
     - python >=3.7
-    - packaging >=17.0
-    - numpy  >=1.17.2
-    - pyyaml  >=5.4
-    - pytorch >=1.9
-    - tqdm  >=4.57.0
-    - tensorboard >=2.9.1
-    - fsspec[http] >=2021.05.0, !=2021.06.0
-    - torchmetrics >=0.7.0
-    - pyDeprecate >=0.3.1
-    - typing-extensions >=4.0.0
+    - packaging >=17.0, <=21.3
+    - numpy >=1.17.2, <1.23.1
+    - pyyaml >=5.4, <=6.0
+    - pytorch >=1.9.*, <1.13.0
+    - tqdm >=4.57.0, <4.65.0
+    - tensorboard >=2.9.1, <2.11.0
+    - fsspec[http] >2021.06.0, <2022.8.0
+    - torchmetrics>=0.7.0, <0.10.1
+    - typing-extensions >=4.0.0, <=4.4.0
+    - lightning-utilities >=0.3.0, <0.4.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,9 +17,9 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python >=3.7, <3.11 # TODO: this upper bound is because of PyTorch issue with dataclass
   run:
-    - python >=3.7
+    - python >=3.7, <3.11 # TODO: this upper bound is because of PyTorch issue with dataclass
     - packaging >=17.0
     - numpy >=1.17.2
     - pyyaml >=5.4
@@ -37,6 +37,7 @@ test:
   #commands:
   #  - pip check
   requires:
+    - python >=3.7, <3.11 # TODO: this upper bound is because of PyTorch issue with dataclass
     - pip
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,16 +20,16 @@ requirements:
     - python >=3.6
   run:
     - python >=3.7
-    - packaging >=17.0, <=21.3
-    - numpy >=1.17.2, <1.23.1
-    - pyyaml >=5.4, <=6.0
-    - pytorch >=1.9.*, <1.13.0
-    - tqdm >=4.57.0, <4.65.0
-    - tensorboard >=2.9.1, <2.11.0
-    - fsspec[http] >2021.06.0, <2022.8.0
-    - torchmetrics >=0.7.0, <0.10.1
-    - typing-extensions >=4.0.0, <=4.4.0
-    - lightning-utilities >=0.3.0, <0.4.0
+    - packaging >=17.0
+    - numpy >=1.17.2
+    - pyyaml >=5.4
+    - pytorch >=1.9.0
+    - tqdm >=4.57.0
+    - tensorboard >=2.9.1
+    - fsspec[http] >2021.06.0
+    - torchmetrics >=0.7.0
+    - typing-extensions >=4.0.0
+    - lightning-utilities >=0.3.0, !=0.4.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - tqdm >=4.57.0, <4.65.0
     - tensorboard >=2.9.1, <2.11.0
     - fsspec[http] >2021.06.0, <2022.8.0
-    - torchmetrics>=0.7.0, <0.10.1
+    - torchmetrics >=0.7.0, <0.10.1
     - typing-extensions >=4.0.0, <=4.4.0
     - lightning-utilities >=0.3.0, <0.4.0
 


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] ~~Bumped the build number (if the version is unchanged)~~
* [X] Reset the build number to `0` (if the version changed) -- (set the build at 0 because previous v1.8.1 build was never successful)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

* I've skipped `v1.8.0` because of the `lightning-lite` dependency in that version only.
* Now that `lightning-utilities` has `v0.3.0` on conda-forge, the build is successful locally.
* I've added the upper bounds of the dependencies to be in line with upstream. (This was necessary for `pytorch` dependency as local build was failing without it).

Closes #105